### PR TITLE
Fix twitter_user table to correctly handle not found errors for the `pinned_tweet` column Closes #23

### DIFF
--- a/twitter/table_twitter_user.go
+++ b/twitter/table_twitter_user.go
@@ -51,7 +51,7 @@ func listUser(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 		return nil, lookupErr
 	}
 
-	softError := []*twitter.ErrorObj{}
+	softErrors := []*twitter.ErrorObj{}
 
 	// Soft error, e.g. 404
 	if len(result.Raw.Errors) > 0 {
@@ -65,13 +65,13 @@ func listUser(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 				}
 				return nil, nil
 			}
-			softError = append(softError, e)
+			softErrors = append(softErrors, e)
 		}
 	}
 
-	if len(softError) > 0 {
+	if len(softErrors) > 0 {
 		errMsgs := []string{}
-		for _, e := range softError {
+		for _, e := range softErrors {
 			errMsgs = append(errMsgs, fmt.Sprintf("%s: %s", e.Title, e.Detail))
 		}
 		// Return the full set of error messages

--- a/twitter/table_twitter_user.go
+++ b/twitter/table_twitter_user.go
@@ -55,10 +55,8 @@ func listUser(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 
 	// Soft error, e.g. 404
 	if len(result.Raw.Errors) > 0 {
-		errMsgs := []string{}
 		for _, e := range result.Raw.Errors {
 			plugin.Logger(ctx).Error("twitter_user.listUser", "query_error", e, "opts", opts)
-			errMsgs = append(errMsgs, fmt.Sprintf("%s: %s", e.Title, e.Detail))
 			
 			// Check if the Not Found Error is a result of "pinned_tweet_id" parameter, return nil
 			if e.Title == "Not Found Error" {

--- a/twitter/table_twitter_user.go
+++ b/twitter/table_twitter_user.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+
 	twitter "github.com/g8rswimmer/go-twitter/v2"
 
 	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
@@ -49,19 +50,36 @@ func listUser(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (
 		plugin.Logger(ctx).Error("twitter_user.listUser", "query_error", lookupErr, "opts", opts)
 		return nil, lookupErr
 	}
+
+	softError := []*twitter.ErrorObj{}
+
 	// Soft error, e.g. 404
 	if len(result.Raw.Errors) > 0 {
 		errMsgs := []string{}
 		for _, e := range result.Raw.Errors {
 			plugin.Logger(ctx).Error("twitter_user.listUser", "query_error", e, "opts", opts)
 			errMsgs = append(errMsgs, fmt.Sprintf("%s: %s", e.Title, e.Detail))
+			
+			// Check if the Not Found Error is a result of "pinned_tweet_id" parameter, return nil
 			if e.Title == "Not Found Error" {
+				if e.Parameter == "pinned_tweet_id" {
+					continue
+				}
 				return nil, nil
 			}
+			softError = append(softError, e)
+		}
+	}
+
+	if len(softError) > 0 {
+		errMsgs := []string{}
+		for _, e := range softError {
+			errMsgs = append(errMsgs, fmt.Sprintf("%s: %s", e.Title, e.Detail))
 		}
 		// Return the full set of error messages
 		return nil, errors.New(strings.Join(errMsgs, "\n"))
 	}
+
 	for _, i := range result.Raw.UserDictionaries() {
 		d.StreamListItem(ctx, i)
 	}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
select * from twitter_user where username='a_garfield101'
[
 {
  "_ctx": {
   "connection_name": "twitter"
  },
  "created_at": "2010-01-26T22:26:07+05:30",
  "description": "Somewhere between art and technology. Thoughts and words are all mine. QA Engineer @elastic",
  "entities": {
   "annotations": null,
   "cashtags": null,
   "hashtags": null,
   "mentions": null,
   "urls": null
  },
  "id": "108656083",
  "location": "Maryland",
  "name": "Andrew Garfield",
  "pinned_tweet": null,
  "pinned_tweet_id": "935639732112982017",
  "profile_image_url": "https://pbs.twimg.com/profile_images/1243707147164307461/S6tMKyAq_normal.jpg",
  "protected": "false",
  "public_metrics": {
   "followers_count": 347,
   "following_count": 107,
   "listed_count": 11,
   "tweet_count": 4963
  },
  "url": "https://t.co/aY1u1517Ws",
  "username": "a_garfield101",
  "verified": false,
  "withheld": null
 }
]
```
</details>
